### PR TITLE
Create incidents in Cachet when status changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ celerybeat*
 static
 shared/*
 !shared/.gitkeep
+env

--- a/isserviceup/notifiers/cachet.py
+++ b/isserviceup/notifiers/cachet.py
@@ -22,8 +22,24 @@ class CachetStatus(Enum):
             Status.unavailable: CachetStatus.critical,
         }
         status = status and Status[status]
-        return (status_map[status].value if status in status_map
-                else CachetStatus.critical.value)
+        return status_map.get(status, CachetStatus.critical)
+
+    @staticmethod
+    def get_status_name(status):
+        status_name = {
+            CachetStatus.ok: 'OK',
+            CachetStatus.minor: 'Minor',
+            CachetStatus.major: 'Major',
+            CachetStatus.critical: 'Critical',
+        }
+        return status_name.get(status, 'Undefined')
+
+    @staticmethod
+    def get_incident_status(status):
+        if status == CachetStatus.ok:
+            return 4  # Solved
+        else:
+            return 1  # Investigating
 
 
 class Cachet(Notifier):
@@ -65,15 +81,15 @@ class Cachet(Notifier):
     def _get_component_name(self, service):
         return service.id
 
-    def _get_component_url(self, service):
+    def _get_component_id(self, service):
         component = self._get_component_name(service)
-        if component in self.cachet_components:
-            url = "{base_url}/api/v1/components/{component}".format(
-                base_url=self.cachet_url.strip("/"),
-                component=self.cachet_components[component]
-            )
-            return url
-        return False
+        return self.cachet_components.get(component)
+
+    def _get_component_url(self, service):
+        url = "{base_url}/api/v1/incidents".format(
+            base_url=self.cachet_url.strip("/")
+        )
+        return url
 
     def _get_headers(self):
         return {
@@ -83,22 +99,32 @@ class Cachet(Notifier):
 
     def _build_payload(self, service, old_status, new_status):
         payload = {
-            'name': service.name,
-            'status': CachetStatus.get_cachet_status(new_status),
-            'old_status': CachetStatus.get_cachet_status(old_status),
+            'name': 'Status changed',
+            'message': 'Service **{service}** changed from *{old}* to *{new}*'.format(
+                service=service.name,
+                old=CachetStatus.get_status_name(old_status),
+                new=CachetStatus.get_status_name(new_status)
+            ),
+            'status': CachetStatus.get_incident_status(new_status),
+            'visible': 1,
+            'component_id': self._get_component_id(service),
+            'component_status': new_status.value,
+            'notify': True
         }
         return payload
 
     def _is_valid(self, service):
         return (
             self.cachet_url and self.cachet_token and self.cachet_components
-            and self._get_component_name(service) in self.cachet_components
+            and self._get_component_id(service)
         )
 
     def notify(self, service, old_status, new_status):
-        if self._is_valid(service):
+        old_status = CachetStatus.get_cachet_status(old_status)
+        new_status = CachetStatus.get_cachet_status(new_status)
+        if self._is_valid(service) and old_status != new_status:
             url = self._get_component_url(service)
             headers = self._get_headers()
             payload = self._build_payload(service, old_status, new_status)
             print("Notifying {} with {}".format(url, payload))
-            requests.put(url, json=payload, headers=headers)
+            requests.post(url, json=payload, headers=headers)


### PR DESCRIPTION
Now when a status changes, `is-service-up` notifies cachet to create a new `incident` containing a message with the old status and the new one.

![image](https://user-images.githubusercontent.com/8657959/27048615-85f9e600-4f7a-11e7-96b0-d5a09f54170b.png)

![image](https://user-images.githubusercontent.com/8657959/27048617-870072bc-4f7a-11e7-9207-fd953e5ec4d3.png)
